### PR TITLE
Add repository link to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 authors = ["VanillaBrooks <brooks@karlik.org>"]
 edition = "2018"
 description = "qbittorrent web api implementation"
+repository = "https://github.com/VanillaBrooks/qbittorrent"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Makes it easier to access the repository from both docs.rs and crates.io